### PR TITLE
refactor(archive): update ob-archive command

### DIFF
--- a/content/.opencode/commands/ob-archive.md
+++ b/content/.opencode/commands/ob-archive.md
@@ -1,30 +1,53 @@
 ---
-description: Archive a completed OpenSpec change and update documentation. Triggered by /ob-archive <url|changeId> command.
+description: Archive the oldest merged unarchived OpenSpec change and update documentation.
 ---
 
-> **Command aliases:** Loaded skills may reference `/opsx-propose`, `/opsx-apply`, `/opsx-archive`, or `/opsx-explore`. Always substitute: `/opsx-propose` → `/ob-propose`, `/opsx-apply` → `/ob-apply`, `/opsx-archive` → `/ob-archive`, `/opsx-explore` → `/ob-explore`. Never mention the `opsx-` names in your responses to the user.
+> **Command aliases:** Loaded skills may reference `/opsx-propose`, `/opsx-apply`, `/opsx-archive`, or `/opsx-explore`. Always substitute: `/opsx-propose` -> `/ob-propose`, `/opsx-apply` -> `/ob-apply`, `/opsx-archive` -> `/ob-archive`, `/opsx-explore` -> `/ob-explore`. Never mention the `opsx-` names in your responses to the user.
 
-Apply `## Optimizations` from AGENTS.md (RTK, codegraph, memory, etc.).
+Apply `## Optimizations` from AGENTS.md (RTK, codegraph, memory, etc.). Load `@ob-global`.
 
-**Input**: A change ID. (`us-{id}-{slug}` or PR URL)
+Archive the oldest merged unarchived OpenSpec change, update documentation, and create an archive PR. No input required — the command automatically finds the correct change.
 
-**Steps:**
+**Steps**
 
-1. **Load baseline**
-   Load `@ob-global`
+1. **Prepare working tree**
 
-2. **Update main branch**
-   - Switch to main branch and pull the latest changes to ensure it's up to date:
-     ```bash
-     git switch main
-     git pull origin main
-     ```
-   - If there are changes in current branch (when switching or pulling), stash them and warn the user.
-   - Do not apply the stashed changes to the new archive branch, as the archive branch should only contain the changes related to the merged PR.
+   Resolve the repo root and capture current git state:
 
-3. **Find the change**
-   - Try to match a change from `openspec/changes` with the provided change ID or PR URL.
-   - If the change is not found, report as a blocker and do not proceed with archiving.
+   ```bash
+   REPO_ROOT="$(git rev-parse --show-toplevel)"
+   git branch --show-current
+   git status --porcelain
+   ```
+
+   If the current branch is not `main` and there are uncommitted changes, stash them:
+
+   ```bash
+   git stash push -m "WIP before archive"
+   ```
+
+   Warn the user before exit if anything was stashed. Then update `main`:
+
+   ```bash
+   git switch main
+   git pull origin main
+   ```
+
+2. **Get the list of unarchived changes**
+
+   List unarchived changes from the top level of `openspec/changes/`:
+
+   ```bash
+   find "$REPO_ROOT/openspec/changes" -mindepth 1 -maxdepth 1 -type d -name 'us-*' | sort
+   ```
+
+   If the list is empty, verify the parent directory once:
+
+   ```bash
+   ls -la "$REPO_ROOT/openspec/changes"
+   ```
+
+   If there are still no unarchived change directories, report a blocker and stop.
 
 <!-- OB-PLATFORM-ARCHIVE-START -->
 <!-- OB-PLATFORM-ARCHIVE-END -->

--- a/src/presets/ob-archive-az.md
+++ b/src/presets/ob-archive-az.md
@@ -6,7 +6,7 @@
    az repos pr list --repository {repo} --status completed --query "sort_by(@, &closedDate)[].{name:title,sourceRefName:sourceRefName,closedDate:closedDate}"
    ```
 
-   For each unarchived change, try to find a matching PR from the list of merged PRs, using the change ID and slug as search hints.
+   For each unarchived change from the list of unarchived changes (step 2), try to find a matching PR from the list of merged PRs (this step), using the change ID and slug as search hints.
 
    Handle PR matches:
    - No results → record as blocked: `no merged PR found`
@@ -22,11 +22,11 @@
    Sort `eligible` by `closedDate` ascending and display the ordered list. Include blocked items separately. Example:
 
    ```text
-   Unarchived changes, ordered by merge date (oldest first):
+   Unarchived changes, ordered by close date (oldest first):
 
-   1. us-195435-secure-external-lb-iap (merged 2026-05-15T09:22:00Z) <- OLDEST
-   2. us-195448-update-service-names-and-repo (merged 2026-05-18T11:44:00Z)
-   3. us-195462-update-ssl-certs-and-routing (merged 2026-05-20T14:32:00Z)
+   1. us-195435-secure-external-lb-iap (closed 2026-05-15T09:22:00Z) <- OLDEST
+   2. us-195448-update-service-names-and-repo (closed 2026-05-18T11:44:00Z)
+   3. us-195462-update-ssl-certs-and-routing (closed 2026-05-20T14:32:00Z)
 
    Blocked from archiving:
    - us-195499-some-change (no merged PR found)

--- a/src/presets/ob-archive-az.md
+++ b/src/presets/ob-archive-az.md
@@ -1,3 +1,158 @@
+3. **Resolve the oldest merged unarchived change**
+
+   List all merged PRs in the repo using Azure CLI:
+   
+   ```bash
+   az repos pr list --repository {repo} --status completed --query "sort_by(@, &closedDate)[].{name:title,sourceRefName:sourceRefName,closedDate:closedDate}"
+   ```
+
+   For each unarchived change, try to find a matching PR from the list of merged PRs, using the change ID and slug as search hints.
+
+   Handle PR matches:
+   - No results → record as blocked: `no merged PR found`
+   - Exactly one result → keep as the resolved PR
+   - Multiple results → ask the user to pick the correct PR for that change by number or PR ID
+
+   Build two lists:
+   - `eligible`: changes with one resolved merged PR
+   - `blocked`: changes with no resolved merged PR
+
+   If `eligible` is empty, report a blocker and stop.
+
+   Sort `eligible` by `closedDate` ascending and display the ordered list. Include blocked items separately. Example:
+
+   ```text
+   Unarchived changes, ordered by merge date (oldest first):
+
+   1. us-195435-secure-external-lb-iap (merged 2026-05-15T09:22:00Z) <- OLDEST
+   2. us-195448-update-service-names-and-repo (merged 2026-05-18T11:44:00Z)
+   3. us-195462-update-ssl-certs-and-routing (merged 2026-05-20T14:32:00Z)
+
+   Blocked from archiving:
+   - us-195499-some-change (no merged PR found)
+   ```
+
+   Select the first `eligible` item as the archive candidate. Carry its already-resolved PR metadata forward — do not run a second PR lookup.
+
+4. **Confirm the candidate**
+
+   Display the resolved candidate and wait for confirmation:
+
+   ```text
+   Oldest unarchived merged change found:
+     ID: us-{id}-{slug}
+     Title: {title from resolved PR}
+     PR ID: {pullRequestId}
+     Merged: {closedDate}
+
+   Proceed with archiving? [yes/no]
+   ```
+
+   Stop if the user does not confirm.
+
+5. **Archive and update docs**
+
+   Create the archive branch:
+
+   ```bash
+   git checkout -b archive/{id}-{slug}
+   ```
+
+   Archive the change through OpenSpec:
+
+   ```bash
+   openspec archive "us-{id}-{slug}"
+   ```
+
+   Review documentation impact:
+   - Read `$REPO_ROOT/openspec/changes/archive/us-{id}-{slug}/specs/` if the archive moved the change, or `$REPO_ROOT/openspec/changes/us-{id}-{slug}/specs/` if not yet moved.
+   - Compare the implemented change with `ARCHITECTURE.md` and `DESIGN.md`.
+   - If documentation updates are needed, show the proposed changes and get user approval before applying them.
+
+   Commit and push:
+
+   ```bash
+   git add -A
+   git commit -m "archive(us-{id}): {title from resolved PR}"
+   git push origin archive/{id}-{slug}
+   ```
+
+   Create the archive PR:
+
+   ```bash
+   az repos pr create \
+     --repository {repo} \
+     --source-branch refs/heads/archive/{id}-{slug} \
+     --target-branch refs/heads/main \
+     --title "archive(us-{id}): {title}" \
+     --description "Archive SDD artifacts for us-{id} after merge of {sourceRefName}." \
+     --auto-complete
+   ```
+
+   Record the archive PR URL and ID. If work was stashed in step 1, restore it after the archive flow completes unless the user opts out.
+
+6. **Report**
+
+   Display:
+
+   ```text
+   Archive complete
+
+     Change ID: us-{id}-{slug}
+     Title: {title}
+     Original PR: {original-pr-link}
+     Archive PR: {archive-pr-link}
+
+     Documentation updates:
+     - ARCHITECTURE.md: {count} changes applied
+     - DESIGN.md: {count} changes applied
+   ```
+
+   Stop immediately with a clear error if any of these blockers are encountered:
+   - No unarchived change directories under `$REPO_ROOT/openspec/changes/`
+   - No unarchived change has a resolved merged PR
+   - Azure CLI PR queries fail
+   - The selected PR is not `completed`
+
+## Rules
+
+- All OpenSpec paths must resolve from the git repository root (`git rev-parse --show-toplevel`). Never use `/openspec/...`.
+- Use `--repository {repo}` when querying PRs, where `{repo}` is the resolved repository name.
+- Use change ID and slug only as search hints. Do not assume the exact source branch name.
+- Display the full sorted list of eligible unarchived changes before asking for confirmation.
+- The oldest eligible merged change is the only archive candidate. Never ask the user which change to archive.
+- If multiple PRs match a specific change, ask the user which PR belongs to that change.
+- Only process top-level directories in `$REPO_ROOT/openspec/changes/`. Exclude archived locations.
+- All archive commits and pushes must use `archive/{id}-{slug}` branches.
+- Never proceed if the selected PR is not merged.
+- Never use browser tools or direct web requests for Azure DevOps. Use `az` CLI only.
+- Never invent or guess PR, branch, or merge metadata.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 4. **Find oldest unarchived change**
    - Calculate the oldest unarchived change:
      - list all merged PRs ordered by merge date, oldest first

--- a/src/presets/ob-archive-gh.md
+++ b/src/presets/ob-archive-gh.md
@@ -6,7 +6,7 @@
    gh pr list --repo {owner}/{repo} --state merged --json title,url,mergedAt --jq 'sort_by(.mergedAt) | .[] | {name: .title, sourceRefName: .headRefName, mergedAt: .mergedAt}'
    ```
 
-   For each unarchived change, try to find a matching PR from the list of merged PRs, using the change ID and slug as search hints.
+   For each unarchived change from the list of unarchived changes (step 2), try to find a matching PR from the list of merged PRs (this step), using the change ID and slug as search hints.
 
    Handle PR matches:
    - No results → record as blocked: `no merged PR found`

--- a/src/presets/ob-archive-gh.md
+++ b/src/presets/ob-archive-gh.md
@@ -1,50 +1,83 @@
-4. **Find oldest unarchived change**
-   - Calculate the oldest unarchived change:
-     - list all merged PRs ordered by merge date, oldest first
-       ```bash
-       gh pr list --repo {owner}/{repo} --state merged --json title,url,mergedAt --jq 'sort_by(.mergedAt) | .[] | {name: .title, url: .url}'
-       ```
-     - compare unarchived changes in `openspec/changes` with the list of merged PRs to find the oldest merged unarchived change.
-     - oldest unarchived changes that have already been merged should be archived first, before newer changes can be archived.
+3. **Resolve the oldest merged unarchived change**
 
-   - If the change matched in step 2 is not the oldest, report that there are oldest changes that need to be archived first and do not proceed with archiving. Include the list of unarchived changes in the message and which one should be archived first.
-   - If the change matched in step 2 is the oldest, ask the user to confirm that they want to proceed with archiving this change. If the user does not confirm, do not proceed with archiving.
-
-5. **Create archive branch**
-   - Create a new branch named `archive/{id}-{slug}` based on main:
-     ```bash
-     git checkout -b archive/{id}-{slug}
-     ```
-
-6. **Archive**
-
-   Step 1: Find PR and verify merged
-
+   List all merged PRs in the repo using GitHub CLI:
+   
    ```bash
-   gh pr list \
-   --repo {owner}/{repo} \
-   --head feature/{id}-{slug} \
-   --state closed
+   gh pr list --repo {owner}/{repo} --state merged --json title,url,mergedAt --jq 'sort_by(.mergedAt) | .[] | {name: .title, sourceRefName: .headRefName, mergedAt: .mergedAt}'
    ```
 
-   - If a matching PR is found, verify that its status is "completed" (merged).
-   - If no matching PR is found, or if the PR is not merged, report as a blocker and do not proceed with archiving.
+   For each unarchived change, try to find a matching PR from the list of merged PRs, using the change ID and slug as search hints.
 
-   Step 2: Verify and update AI files
+   Handle PR matches:
+   - No results → record as blocked: `no merged PR found`
+   - Exactly one result → keep as the resolved PR
+   - Multiple results → ask the user to pick the correct PR for that change by number or PR ID
 
-   ```bash
-   /opsx-verify us-{id}-{slug} # or /opsx-validate us-{id}-{slug}
-   /opsx-archive us-{id}-{slug}
+   Build two lists:
+   - `eligible`: changes with one resolved merged PR
+   - `blocked`: changes with no resolved merged PR
+
+   If `eligible` is empty, report a blocker and stop.
+
+   Sort `eligible` by `mergedAt` ascending and display the ordered list. Include blocked items separately. Example:
+
+   ```text
+   Unarchived changes, ordered by merge date (oldest first):
+
+   1. us-195435-secure-external-lb-iap (merged 2026-05-15T09:22:00Z) <- OLDEST
+   2. us-195448-update-service-names-and-repo (merged 2026-05-18T11:44:00Z)
+   3. us-195462-update-ssl-certs-and-routing (merged 2026-05-20T14:32:00Z)
+
+   Blocked from archiving:
+   - us-195499-some-change (no merged PR found)
    ```
 
-   Step 3: Update ARCHITECTURE and DESIGN files
-   - Review ARCHITECTURE.md and DESIGN.md and find discrepancies compared to the change implementation. Discrepancies include any new architectural decisions, design changes, or implementation details that are not yet captured in the documentation.
-   - Make sure all discrepancies are properly documented in ARCHITECTURE.md and DESIGN.md, so the documentation is up to date with the change implementation.
-   - Updates to ARCHITECTURE.md and DESIGN.md should be treated as conflicts, so the user must explicitly consent to the changes before they are applied. This ensures that the user reviews and approves all documentation updates related to the change.
-   - Let the user know the discrepancies found and the proposed updates to ARCHITECTURE.md and DESIGN.md, and ask for their consent before applying the changes. If the user does not consent, do not apply the updates to the documentation.
-   - Only review implementation for this specific change, do not review or update documentation for any other unrelated changes that may be present in the codebase. The focus should be solely on ensuring that the documentation accurately reflects the implementation of the specific change being archived.
+   Select the first `eligible` item as the archive candidate. Carry its already-resolved PR metadata forward — do not run a second PR lookup.
 
-   Step 4: Create archive PR
+4. **Confirm the candidate**
+
+   Display the resolved candidate and wait for confirmation:
+
+   ```text
+   Oldest unarchived merged change found:
+     ID: us-{id}-{slug}
+     Title: {title from resolved PR}
+     PR ID: {pullRequestId}
+     Merged: {closedDate}
+
+   Proceed with archiving? [yes/no]
+   ```
+
+   Stop if the user does not confirm.
+
+5. **Archive and update docs**
+
+   Create the archive branch:
+
+   ```bash
+   git checkout -b archive/{id}-{slug}
+   ```
+
+   Archive the change through OpenSpec:
+
+   ```bash
+   openspec archive "us-{id}-{slug}"
+   ```
+
+   Review documentation impact:
+   - Read `$REPO_ROOT/openspec/changes/archive/us-{id}-{slug}/specs/` if the archive moved the change, or `$REPO_ROOT/openspec/changes/us-{id}-{slug}/specs/` if not yet moved.
+   - Compare the implemented change with `ARCHITECTURE.md` and `DESIGN.md`.
+   - If documentation updates are needed, show the proposed changes and get user approval before applying them.
+
+   Commit and push:
+
+   ```bash
+   git add -A
+   git commit -m "archive(us-{id}): {title from resolved PR}"
+   git push origin archive/{id}-{slug}
+   ```
+
+   Create the archive PR:
 
    ```bash
    gh pr create \
@@ -55,19 +88,41 @@
    --body "Archive SDD artifacts for {id} after merge."
    ```
 
-7. **Summary**
+   Record the archive PR URL and ID. If work was stashed in step 1, restore it after the archive flow completes unless the user opts out.
+
+6. **Report**
+
    Display:
-   - Change ID and title
-   - Link to new archive PR
-   - Changes applied to ARCHITECTURE.md and DESIGN.md
 
-**Rules:**
+   ```text
+   Archive complete
 
-- ✅ Commit and push to archive branches only
-- ✅ Create and comment on PRs via gh CLI with explicit `--repo {owner}/{repo}`
-- ✅ All GitHub data MUST come from `gh` CLI.
-- ✅ Always pass `--repo {owner}/{repo}` explicitly, never rely on git context to resolve the repo.
-- ❌ Never proceed with archiving if the corresponding PR is not merged.
-- ❌ Never proceed with archiving if there are older unarchived changes.
-- ❌ Never navigate browser to github.com
-- ❌ Never use webfetch, HTTP requests, or browser MCP tools for GitHub operations, even if gh CLI fails. If `gh` is unavailable, report as a blocker.
+     Change ID: us-{id}-{slug}
+     Title: {title}
+     Original PR: {original-pr-link}
+     Archive PR: {archive-pr-link}
+
+     Documentation updates:
+     - ARCHITECTURE.md: {count} changes applied
+     - DESIGN.md: {count} changes applied
+   ```
+
+   Stop immediately with a clear error if any of these blockers are encountered:
+   - No unarchived change directories under `$REPO_ROOT/openspec/changes/`
+   - No unarchived change has a resolved merged PR
+   - GitHub CLI PR queries fail
+   - The selected PR is not `merged`
+
+## Rules
+
+- All OpenSpec paths must resolve from the git repository root (`git rev-parse --show-toplevel`). Never use `/openspec/...`.
+- Use `--repo {owner}/{repo}` when querying PRs, where `{repo}` is the resolved repository name.
+- Use change ID and slug only as search hints. Do not assume the exact source branch name.
+- Display the full sorted list of eligible unarchived changes before asking for confirmation.
+- The oldest eligible merged change is the only archive candidate. Never ask the user which change to archive.
+- If multiple PRs match a specific change, ask the user which PR belongs to that change.
+- Only process top-level directories in `$REPO_ROOT/openspec/changes/`. Exclude archived locations.
+- All archive commits and pushes must use `archive/{id}-{slug}` branches.
+- Never proceed if the selected PR is not merged.
+- Never use browser tools or direct web requests for GitHub. Use `gh` CLI only.
+- Never invent or guess PR, branch, or merge metadata.


### PR DESCRIPTION
- Command does not need a input ID, it automatically takes the oldest change to archive
- Command is now more deterministic with clearer steps