### PR TITLE
docs: name the product Plain Concepts Platform Harness, release 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧰 agent-harness
 
-**Installs and maintains an agent harness in any codebase. Wires [OpenCode](https://opencode.ai), [OpenSpec](https://github.com/fission-ai/openspec), [codegraph](https://github.com/colbymchenry/codegraph), and [agentmemory](https://github.com/rohitg00/agentmemory) into a multi-agent development workflow powered by native parallel subagents.**
+**Installs the Plain Concepts Platform Harness into any codebase, and keeps it up to date. Wires [OpenCode](https://opencode.ai), [OpenSpec](https://github.com/fission-ai/openspec), [codegraph](https://github.com/colbymchenry/codegraph), and [agentmemory](https://github.com/rohitg00/agentmemory) into a multi-agent workflow that runs on native parallel subagents.**
 
 GitHub, Azure DevOps, Jira, GitLab, browser-based backlog, or combinations (for example, Jira backlog plus GitHub repository, or browser backlog plus GitLab repository).
 
@@ -19,19 +19,23 @@ GitHub, Azure DevOps, Jira, GitLab, browser-based backlog, or combinations (for 
 
 ## What is this?
 
-Most codebases have no `AGENTS.md`, no architecture documentation that agents can read, and no defined workflow for picking up tasks. Agents end up improvising, producing inconsistent results.
+Most codebases have no `AGENTS.md`, no architecture documentation an agent can read, and no defined workflow for picking up a task. So agents improvise, and you get a different answer every run.
 
-**agent-harness** is a CLI that installs a *harness* into your repository, then keeps it current. The harness is the set of files agents actually work from: slash commands, `pc-*` skills, an agent team, OpenCode plugins, an OpenSpec workspace, and generated `ARCHITECTURE.md` / `DESIGN.md`. It configures OpenCode with OpenSpec for structured change management, native subagent waves for parallel execution, codegraph for code intelligence, and agentmemory for shared context across sessions.
+**agent-harness** is the CLI that installs the **Plain Concepts Platform Harness** into a repository and keeps it up to date.
 
-Three verbs cover its whole life cycle:
+The harness is ours. We build it, our projects run on it, and this CLI is how it gets into a codebase. It is the set of files agents work from: slash commands, `pc-*` skills (the `pc-` is Plain Concepts), an agent team, OpenCode plugins, an OpenSpec workspace, and generated `ARCHITECTURE.md` and `DESIGN.md`.
 
-| | |
+Underneath, it wires OpenCode to OpenSpec for change management, native subagent waves for parallel work, codegraph for code intelligence, and agentmemory for context that survives between sessions.
+
+The CLI has three jobs:
+
+| Command | What it does |
 | --- | --- |
-| **install** | `npx @plainconceptsplatform/agent-harness` — a wizard runs once, writes the harness, records your choices in `.opencode/harness.json` |
-| **update** | `npx @plainconceptsplatform/agent-harness update` — re-applies the harness from those saved choices, with no prompts, preserving files you have edited |
-| **join** | `npx @plainconceptsplatform/agent-harness join` — a new teammate installs the local tooling the harness expects, touching no committed file |
+| `npx @plainconceptsplatform/agent-harness` | Installs the harness. A wizard runs once and saves your answers to `.opencode/harness.json`. |
+| `npx @plainconceptsplatform/agent-harness update` | Reinstalls the harness from those saved answers, no questions asked. Keeps files you edited. |
+| `npx @plainconceptsplatform/agent-harness join` | Sets up a teammate's machine. Touches no committed file. |
 
-The wizard is the first of those three, not the product.
+You run the first one once per repository, and the second whenever we ship a release.
 
 <div align="center">
 <img src="https://raw.githubusercontent.com/PlainConceptsPlatform/agent-harness/refs/heads/main/docs/public/assets/demo.gif" alt="agent-harness demo" width="700" />
@@ -76,7 +80,7 @@ A new release of agent-harness ships new commands, skills and plugins. To pull t
 npx @plainconceptsplatform/agent-harness@latest update
 ```
 
-`update` re-runs every file patch from `.opencode/harness.json` without asking anything. It tracks a hash of each file it manages in `.opencode/harness-managed.json`, so anything you have edited by hand is preserved rather than overwritten, and generated skills such as `pc-guardrails-project` are left alone.
+`update` re-runs every file patch from `.opencode/harness.json` and asks nothing. It keeps a hash of each file it manages in `.opencode/harness-managed.json`, so it leaves your hand edits alone and reports them as preserved. It also skips generated skills like `pc-guardrails-project`, whose contents came from a `/make-*` command rather than from us.
 
 Reach for individual steps when you want something narrower:
 
@@ -86,7 +90,7 @@ Reach for individual steps when you want something narrower:
 - `metadata` last, to refresh `.opencode/harness.json`
 - `join` if you are new to a project that already has the harness and want the local tooling it expects
 
-> **Upgrading from `opencode-onboard` v1?** v2 renamed the config files and the skill prefix (`ob-` → `pc-`) and does not migrate v1 projects. The CLI detects one and refuses to run rather than half-patching it. Re-onboard on a clean branch: remove `.opencode/` and `.agents/skills/ob-*`, then run the wizard again.
+> **Upgrading from `opencode-onboard` v1?** v2 renamed the config files and the skill prefix (`ob-` became `pc-`), and it does not migrate v1 projects. The CLI detects one and refuses to run rather than half-patching it. Re-onboard on a clean branch: remove `.opencode/` and `.agents/skills/ob-*`, then run the wizard again.
 
 ---
 
@@ -121,7 +125,7 @@ OpenCode asks if this is a greenfield or brownfield project. For brownfield proj
 
 Custom slash commands are installed into `.opencode/commands/` and are available directly in OpenCode.
 
-Commands that other commands (or agents) need to execute are thin wrappers around `pc-*` skills in `.agents/skills/` — the command handles user invocation and arguments, the skill holds the procedure. OpenCode has no mechanism for a command to run another command, but any agent can load a skill mid-conversation, which is what makes pipelines like `/plan-goal` composable.
+Commands that other commands (or agents) need to execute are thin wrappers around `pc-*` skills in `.agents/skills/`. The command handles user invocation and arguments, and the skill holds the procedure. OpenCode has no mechanism for a command to run another command, but any agent can load a skill mid-conversation, which is what makes pipelines like `/plan-goal` composable.
 
 | Command | Description |
 | ------- | ----------- |
@@ -165,7 +169,7 @@ fullstack-engineer     primary planning agent, accumulates all skills (user-faci
 *-engineer             user-created specialists, spawned by the lead for parallel implementation
 ```
 
-`fullstack-engineer` is `mode: primary` — it's the user's planning session agent, not a spawned worker. Project-specific specialization comes from user-created custom engineers via `/make-engineer`. During `/plan-apply`, the lead inspects the engineers that actually exist in `.opencode/agents/` and spawns matching specialists. `fullstack-engineer` is never assigned to tasks — if no specialist matches, the user should create one.
+`fullstack-engineer` is `mode: primary`, so it is the user's planning session agent rather than a spawned worker. Project-specific specialization comes from user-created custom engineers via `/make-engineer`. During `/plan-apply`, the lead inspects the engineers that actually exist in `.opencode/agents/` and spawns matching specialists. `fullstack-engineer` is never assigned to tasks. If no specialist matches, the user should create one.
 
 ### Skills, platform knowledge
 
@@ -371,7 +375,7 @@ The CLI is organized around the ten wizard steps: one directory per step under `
 
 Data the CLI reads lives in two places, split by kind:
 
-**`src/presets/`** — JSON that shapes the wizard's questions and defaults:
+**`src/presets/`** holds JSON that shapes the wizard's questions and defaults:
 
 - `source.json` controls source-scope prompt options
 - `platforms.json` controls platform labels, CLI checks, and backlog-only flags
@@ -381,13 +385,13 @@ Data the CLI reads lives in two places, split by kind:
 - `quota.json` controls opencode-quota defaults
 - `browser.json` controls opencode-browser installer automation
 
-**`src/fragments/`** — Markdown injected into the installed harness, one directory per marker family: `archive/`, `guardrails/`, `ops-backlog/`, `ops-evidence/`, `ops-review/`, `ops-ship/`. Each file is the platform-specific body that replaces a `<!-- PC-PLATFORM-*-START -->` block.
+**`src/fragments/`** holds Markdown injected into the installed harness, one directory per marker family: `archive/`, `guardrails/`, `ops-backlog/`, `ops-evidence/`, `ops-review/`, `ops-ship/`. Each file is the platform-specific body that replaces a `<!-- PC-PLATFORM-*-START -->` block.
 
-**`src/content/`** is the payload itself: everything copied verbatim into the target repository.
+**`src/content/`** is the payload itself, meaning everything copied verbatim into the target repository.
 
 Every filename the harness writes into a project is declared once in `src/utils/paths.js`. Change it there, and remember the OpenCode plugins under `src/content/.opencode/plugins/` read those same names at runtime.
 
-`skills/` holds skills *about this CLI*, for agents that have to operate it — see [skills/README.md](./skills/README.md). They are not published to npm and are distinct from the `pc-*` skills in `src/content/` that get installed into your project.
+`skills/` holds skills *about this CLI*, for agents that have to operate it. See [skills/README.md](./skills/README.md). They are not published to npm, and they are separate from the `pc-*` skills in `src/content/` that get installed into your project.
 
 ```bash
 git clone https://github.com/PlainConceptsPlatform/agent-harness.git

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-description: Install agent-harness, satisfy the prerequisites, and rerun individual steps.
+description: Install the harness, satisfy the prerequisites, and keep it up to date.
 ---
 
 <Callout title="Requires Node.js 18 or higher" type="warn">
@@ -102,9 +102,9 @@ tracks a hash of each file it manages in `.opencode/harness-managed.json`, so an
 edited by hand is preserved rather than overwritten.
 
 <Callout type="warn" title="Upgrading from opencode-onboard v1">
-  v2 renamed the config files and the skill prefix (`ob-` → `pc-`), and it does not migrate v1
-  projects. The CLI detects one and refuses to run rather than half-patching it. Re-onboard on a
-  clean branch: remove `.opencode/` and `.agents/skills/ob-*`, then run the wizard again.
+  v2 renamed the config files and the skill prefix (`ob-` became `pc-`), and it does not migrate
+  v1 projects. The CLI detects one and refuses to run rather than half-patching it. Re-onboard on
+  a clean branch: remove `.opencode/` and `.agents/skills/ob-*`, then run the wizard again.
 </Callout>
 
 ## Narrower reruns
@@ -129,8 +129,8 @@ edited by hand is preserved rather than overwritten.
 </Accordion>
 
 <Accordion title="Joining a project that already has the harness">
-  Run `join`. It installs the local tooling the harness expects — platform CLIs, plugins, skills,
-  OpenSpec — and touches no committed file.
+  Run `join`. It installs the local tooling the harness expects (platform CLIs, plugins, skills,
+  OpenSpec) and touches no committed file.
 </Accordion>
 
 </Accordions>

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,33 +1,36 @@
 ---
 title: Introduction
-description: What agent-harness is, and what the harness it installs consists of.
+description: What agent-harness is, and what the Plain Concepts Platform Harness gives you.
 ---
 
-Most codebases have no `AGENTS.md`, no architecture documentation that agents can
-read, and no defined workflow for picking up tasks. Agents end up improvising,
-producing inconsistent results.
+Most codebases have no `AGENTS.md`, no architecture documentation an agent can
+read, and no defined workflow for picking up a task. So agents improvise, and you
+get a different answer every run.
 
-**agent-harness** is a CLI that installs a *harness* into your repository, then
-keeps it current. The harness is the set of files agents actually work from:
-slash commands, `pc-*` skills, an agent team, OpenCode plugins, an OpenSpec
-workspace, and generated `ARCHITECTURE.md` / `DESIGN.md`.
+**agent-harness** is the CLI that installs the **Plain Concepts Platform
+Harness** into a repository and keeps it up to date.
 
-It configures [OpenCode](https://opencode.ai) with
-[OpenSpec](https://github.com/fission-ai/openspec) for structured change
-management, native subagent waves for parallel agent execution,
+The harness is ours. We build it, our projects run on it, and this CLI is how it
+gets into a codebase. It is the set of files agents work from: slash commands,
+`pc-*` skills (the `pc-` is Plain Concepts), an agent team, OpenCode plugins, an
+OpenSpec workspace, and generated `ARCHITECTURE.md` and `DESIGN.md`.
+
+Underneath, it wires [OpenCode](https://opencode.ai) to
+[OpenSpec](https://github.com/fission-ai/openspec) for change management, native
+subagent waves for parallel work,
 [codegraph](https://github.com/colbymchenry/codegraph) for code intelligence,
-and [agentmemory](https://github.com/rohitg00/agentmemory) for shared context
-across agent sessions.
+and [agentmemory](https://github.com/rohitg00/agentmemory) for context that
+survives between sessions.
 
-## Three verbs
+## Three jobs
 
 | Command | What it does |
 | --- | --- |
-| *(no argument)* | A wizard runs once, writes the harness, records your choices in `.opencode/harness.json` |
-| `update` | Re-applies the harness from those saved choices, no prompts, preserving files you have edited |
-| `join` | A new teammate installs the local tooling the harness expects, touching no committed file |
+| *(no argument)* | Installs the harness. A wizard runs once and saves your answers to `.opencode/harness.json`. |
+| `update` | Reinstalls the harness from those saved answers, no questions asked. Keeps files you edited. |
+| `join` | Sets up a teammate's machine. Touches no committed file. |
 
-The wizard is the first of those three, not the product.
+You run the first once per repository, and `update` whenever we ship a release.
 
 ## Install
 

--- a/docs/lib/site.ts
+++ b/docs/lib/site.ts
@@ -14,9 +14,9 @@ export const siteName = "agent-harness";
 
 /** Kept in sync with content/docs/index.mdx frontmatter. */
 export const siteDescription =
-  "Prepare any codebase for AI. Wires OpenCode, OpenSpec, codegraph, and agentmemory into a multi-agent development workflow powered by native parallel subagents.";
+  "Installs the Plain Concepts Platform Harness into any codebase, and keeps it up to date. Wires OpenCode, OpenSpec, codegraph, and agentmemory into a multi-agent workflow that runs on native parallel subagents.";
 
-/** The npm package users install. The `bin` it exposes is still `agent-harness`. */
+/** The npm package users install, whose `bin` is `agent-harness`. */
 export const packageName = "@plainconceptsplatform/agent-harness";
 
 export const npmUrl = `https://www.npmjs.com/package/${packageName}`;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@plainconceptsplatform/agent-harness",
   "version": "2.0.0",
-  "description": "Installs and maintains an agent harness in any codebase. Wires OpenCode, OpenSpec, codegraph, and agentmemory into a multi-agent development workflow powered by native parallel subagents.",
+  "description": "Installs the Plain Concepts Platform Harness into any codebase, and keeps it up to date. Wires OpenCode, OpenSpec, codegraph, and agentmemory into a multi-agent workflow that runs on native parallel subagents.",
   "keywords": [
     "opencode",
     "ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plainconceptsplatform/agent-harness",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Installs the Plain Concepts Platform Harness into any codebase, and keeps it up to date. Wires OpenCode, OpenSpec, codegraph, and agentmemory into a multi-agent workflow that runs on native parallel subagents.",
   "keywords": [
     "opencode",
@@ -28,9 +28,9 @@
   },
   "files": [
     "src",
+    "src/content",
     "!src/**/*.test.js",
     "!src/**/__tests__",
-    "src/content",
     "!src/content/**/node_modules"
   ],
   "publishConfig": {

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,11 +1,13 @@
 # skills/
 
-Skills **about** this CLI, for any AI agent that has to operate it.
+Skills **about** this CLI, for any AI agent that has to operate it. The CLI
+installs the Plain Concepts Platform Harness; these help an agent drive the CLI.
 
 These are not the skills the CLI installs. Those live in
 [`src/content/.agents/skills/`](../src/content/.agents/skills) under the `pc-`
-prefix and are copied into a target repository during install. The skills here
-never ship inside the npm package — they document the CLI itself.
+prefix, and the CLI copies them into a target repository during install. The
+skills here never ship inside the npm package, because they document the CLI
+itself.
 
 | Skill | Use it when |
 | --- | --- |

--- a/skills/agent-harness-cli/SKILL.md
+++ b/skills/agent-harness-cli/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: agent-harness-cli
-description: Drive the agent-harness CLI - install the harness into a repository, bring an existing one up to date, set up a teammate's machine, or rerun a single step. Load when asked to install, update, or repair the agent harness, when a repo needs AI/agent scaffolding set up, or when a command like `npx @plainconceptsplatform/agent-harness` fails and needs diagnosing.
+description: Drive the agent-harness CLI - install the Plain Concepts Platform Harness into a repository, bring an existing one up to date, set up a teammate's machine, or rerun a single step. Load when asked to install, update, or repair the Platform Harness, when a repo needs AI/agent scaffolding set up, or when a command like `npx @plainconceptsplatform/agent-harness` fails and needs diagnosing.
 license: MIT
 ---
 
 # agent-harness CLI
 
-`agent-harness` installs a **harness** into a repository and keeps it current. The harness is the set of files agents work from: slash commands, `pc-*` skills, an agent team, OpenCode plugins, an OpenSpec workspace, and generated `ARCHITECTURE.md` / `DESIGN.md`.
+`agent-harness` installs the **Plain Concepts Platform Harness** into a repository and keeps it up to date. The harness is Plain Concepts' own, and it is the set of files agents work from: slash commands, `pc-*` skills (the `pc-` is Plain Concepts), an agent team, OpenCode plugins, an OpenSpec workspace, and generated `ARCHITECTURE.md` and `DESIGN.md`.
 
 Everything runs against the **current working directory**. `cd` into the target repository first; there is no `--path` flag.
 
@@ -16,7 +16,7 @@ Read the repo before running anything. `.opencode/harness.json` is the marker fo
 
 | Situation | Command |
 | --- | --- |
-| No `.opencode/harness.json` | `npx @plainconceptsplatform/agent-harness@latest` — the install wizard |
+| No `.opencode/harness.json` | `npx @plainconceptsplatform/agent-harness@latest` (the install wizard) |
 | Harness present, want the latest release's files | `npx @plainconceptsplatform/agent-harness@latest update` |
 | Harness present, new machine or new teammate | `npx @plainconceptsplatform/agent-harness join` |
 | One specific thing needs redoing | a single step command, see below |
@@ -25,7 +25,7 @@ Requires Node.js 18+.
 
 ## The install wizard is interactive
 
-The wizard asks about source scope, backlog and repository platform, three models, and optional token-optimization tools. **Do not run it in a non-interactive shell** — it will hang or abort. If you cannot present prompts to a human, say so and hand the command to the user rather than trying to drive it.
+The wizard asks about source scope, backlog and repository platform, three models, and optional token-optimization tools. **Do not run it in a non-interactive shell.** It will hang or abort. If you cannot present prompts to a human, say so and hand the command to the user rather than trying to drive it.
 
 Everything else (`update`, and the single-step commands other than `platform`, `models`, `optimization`) runs without prompts.
 
@@ -44,7 +44,7 @@ browser         Install the opencode-browser plugin
 metadata        Rewrite .opencode/harness.json
 ```
 
-`metadata` last if you ran several — it refreshes the config the others read.
+`metadata` last if you ran several, because it refreshes the config the others read.
 
 ## What lands in the repo
 
@@ -61,23 +61,23 @@ metadata        Rewrite .opencode/harness.json
 AGENTS.md ARCHITECTURE.md DESIGN.md
 ```
 
-After a fresh install, the next move is `/repo-initialize` inside OpenCode — that is what generates real `ARCHITECTURE.md` and `DESIGN.md` and activates the agent team. Installing the harness alone does not do it.
+After a fresh install, the next move is `/repo-initialize` inside OpenCode. That is what generates real `ARCHITECTURE.md` and `DESIGN.md` and activates the agent team. Installing the harness alone does not do it.
 
 ## `update` is edit-safe
 
-`update` compares each managed file against the hash recorded in `.opencode/harness-managed.json`. Files you changed by hand are left alone and reported as preserved. Generated skills — `pc-guardrails-project`, `pc-merge-risk-assess` — are never overwritten once populated. So `update` is safe to run repeatedly, and a second consecutive run should report no changes.
+`update` compares each managed file against the hash recorded in `.opencode/harness-managed.json`. Files you changed by hand are left alone and reported as preserved. Generated skills (`pc-guardrails-project`, `pc-merge-risk-assess`) are never overwritten once populated. So `update` is safe to run repeatedly, and a second consecutive run should report no changes.
 
 ## Diagnosing failures
 
-**"This project was set up by opencode-onboard v1"** — the repo has v1 state files or `ob-*` skills. v2 renamed both and does not migrate. Re-onboard on a clean branch; do not try to rename the files by hand, because the marker comments inside the installed skills changed too.
+**"This project was set up by opencode-onboard v1".** The repo has v1 state files or `ob-*` skills. v2 renamed both and does not migrate. Re-onboard on a clean branch; do not try to rename the files by hand, because the marker comments inside the installed skills changed too.
 
-**"No config found. Run the wizard first."** — `update` or a step needs `.opencode/harness.json` and it is absent. Run the wizard.
+**"No config found. Run the wizard first."** `update` or a step needs `.opencode/harness.json` and it is absent. Run the wizard.
 
-**A platform step reports nothing and changes nothing** — platform content is injected into `<!-- PC-PLATFORM-*-START/END -->` marker pairs. If a marker pair is missing from the target file, injection is skipped silently. Check the markers exist before concluding the step worked.
+**A platform step reports nothing and changes nothing.** Platform content is injected into `<!-- PC-PLATFORM-*-START/END -->` marker pairs. If a marker pair is missing from the target file, injection is skipped silently. Check the markers exist before concluding the step worked.
 
-**Skills missing after install** — skill installation ends with `npx skills experimental_install --yes`, run once at the end of the optimization step. If it failed, rerun it directly in the repo.
+**Skills missing after install.** Skill installation ends with `npx skills experimental_install --yes`, run once at the end of the optimization step. If it failed, rerun it directly in the repo.
 
-**Platform CLI warnings** — the harness expects `gh` (GitHub), `az` + azure-devops extension (Azure DevOps), `acli` (Jira), `glab` (GitLab), each authenticated. These are warnings, not fatal; the harness installs, but the matching `/ops-*` flows will not work until the CLI is present.
+**Platform CLI warnings.** The harness expects `gh` (GitHub), `az` + azure-devops extension (Azure DevOps), `acli` (Jira), `glab` (GitLab), each authenticated. These are warnings, not fatal; the harness installs, but the matching `/ops-*` flows will not work until the CLI is present.
 
 ## Rules
 


### PR DESCRIPTION
## Naming

The CLI installs *our* harness, so the docs now say so. "an agent harness" read like a generic noun; it is the **Plain Concepts Platform Harness**, our projects run on it, and naming it that way also explains where the `pc-` skill prefix comes from, which was previously unexplained anywhere.

Reframed in `README.md`, `docs/content/docs/{index,getting-started}.mdx`, the package description, `docs/lib/site.ts`, and `skills/`.

## Copy pass

Run against the humanizer guide (Wikipedia's "Signs of AI writing"):

- removed every em and en dash from the README, the docs pages and `skills/` (§14) — there were ten in the CLI skill alone
- cut participle tails: "Agents end up improvising, producing inconsistent results" became "So agents improvise, and you get a different answer every run" (§3)
- active over passive: "anything you have edited by hand is preserved rather than overwritten" became "it leaves your hand edits alone" (§13)
- replaced inline-header dashes in the Development section with real sentences (§16)

Two em dashes in pre-existing prose were also changed so the README reads consistently.

## Packaging fix

`"src/content"` sat *after* `"!src/**/*.test.js"` in `files`, so it re-included what the negation had just excluded, and `src/content/.opencode/plugins/pc-system-reminders.test.js` was published and copied into every onboarded repo. npm applies these patterns in order, so the negations have to come last.

Nothing referenced the file and the consumer `.opencode/package.json` defines no test script, so dropping it changes no behavior. Tarball: 151 → 150 files, payload otherwise identical (40 skill files, 3 plugins, 21 fragments, 2 tui entries).

## Release

Bumped to **2.0.1**, which is what carries the new description to npm — package metadata only updates on publish.

## Verification

- `pnpm lint` clean, 193 tests passing
- `pnpm --filter agent-harness-docs build` clean
- `npm pack --dry-run` confirms 150 files and zero `.test.js`

No behavior change beyond the packaging fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)